### PR TITLE
Automatically add trailing slash to `index_url` if needed.

### DIFF
--- a/src/wheel_stub/wheel.py
+++ b/src/wheel_stub/wheel.py
@@ -151,13 +151,14 @@ def get_base_domain(config):
     index_url = config.get("index_url", None)
     if WHEEL_STUB_PIP_INDEX_URL:
         index_url = WHEEL_STUB_PIP_INDEX_URL
+    if index_url and not index_url.endswith("/"):
+        index_url += "/"
     return index_url
 
 
 def download_manual(wheel_directory, distribution, version, config):
     base_domain = get_base_domain(config)
     logger.debug(f"Calculated base domain: {base_domain}")
-    # MUST have trailing slash for our index
     project_url = f"{urljoin(base_domain, distribution)}/"
     logger.debug(f"Querying project url: {project_url}")
     try:


### PR DESCRIPTION
- Fixes https://github.com/wheel-next/wheel-stub/issues/12.
