### PR TITLE
WAR stub-only metadata behavior

### DIFF
--- a/src/wheel_stub/wheel.py
+++ b/src/wheel_stub/wheel.py
@@ -240,7 +240,10 @@ def download_wheel(wheel_directory, config_settings):
     config = get_config_from_pyprojecttoml(src_dir)
     distribution = canonicalize_name(metadata["Name"])
     version = metadata["Version"]
-    if config.get("stub_only", None):
+    extra_conf = config.get("extra", None)
+    if extra_conf:
+        config.update(**extra_conf)
+    if config.get("stub_only", False):
         report_install_failure(distribution, version, config, None)
     try:
         return download_manual(wheel_directory, distribution, version, config)


### PR DESCRIPTION
toml doesn't merge tables with the same name with the syntax we were using. These changes allow `stub_only` to be added to a pyproject.toml file robustly.

Changes:
1. Code now uses actual requirement parsing to check for a url dependency
2. Refactored stub-only logic to be simpler.
3. config `[tool.wheel_stub].stub_only` has moved to `[tool.wheel_stub.extra].stub_only`